### PR TITLE
Defender ATP - Commit for preserving the state file content in Test Connectivity if it times out due to lack of manual intervention

### DIFF
--- a/Apps/phwindowsdefenderatp/windowsdefenderatp_connector.py
+++ b/Apps/phwindowsdefenderatp/windowsdefenderatp_connector.py
@@ -558,7 +558,9 @@ class WindowsDefenderAtpConnector(BaseConnector):
 
         action_result = self.add_action_result(ActionResult(dict(param)))
         self.save_progress(DEFENDERATP_MAKING_CONNECTION_MSG)
-        self._state = {}
+
+        if not self._state:
+            self._state = {}
 
         # Get initial REST URL
         ret_val, app_rest_url = self._get_app_rest_url(action_result)


### PR DESCRIPTION
Commit for preserving the state file content in case of Test Connectivity getting timed out when it gets spawned by the Phantom server automatically in a scheduled autonomous way at a particular point of time in the day because connectivity for the Microsoft apps requires manual intervention.

The Phantom server spawns the connectivity actions of all the assets of all the apps on a given Phantom server to check the asset health. Please find the detailed information below as provided by Matt Hanson on this ground.

1. The asset health widget will trigger an asset health check every 6 hours, by default. The interval can be configured by updating system_settings.misc['asset_health_poll_seconds'].
2. The health check can be turned off entirely by setting system_settings.misc['asset_health_poll_enabled'] to False.
3. There is no way to do further filtering at the moment, but there is a clear path to implementing such a feature.