### PR TITLE
Windows Defender ATP: Removing the unwanted import of quote module

### DIFF
--- a/Apps/phwindowsdefenderatp/windowsdefenderatp_connector.py
+++ b/Apps/phwindowsdefenderatp/windowsdefenderatp_connector.py
@@ -10,9 +10,9 @@ import os
 import sys
 import time
 try:
-    from urllib.parse import urlencode, quote
+    from urllib.parse import urlencode
 except:
-    from urllib import urlencode, quote
+    from urllib import urlencode
 import ipaddress
 import pwd
 import grp


### PR DESCRIPTION
Windows Defender ATP: Removing the unwanted import of quote module